### PR TITLE
Add option to work as whitelist instead of blacklist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 # against bad commits.
 
 name: build
-on: [pull_request, push]
+on: [pull_request, push, workflow_dispatch]
 
 jobs:
   build:

--- a/src/main/java/xyz/pupbrained/config/DropConfirmConfig.java
+++ b/src/main/java/xyz/pupbrained/config/DropConfirmConfig.java
@@ -32,6 +32,9 @@ public final class DropConfirmConfig {
   public boolean playSounds = true;
 
   @SerialEntry
+  public boolean treatAsWhitelist = false;
+
+  @SerialEntry
   public double confirmationResetDelay = 1.0;
 
   @SerialEntry
@@ -60,6 +63,15 @@ public final class DropConfirmConfig {
         booleanOption -> new BooleanController(booleanOption, true)
       );
 
+      var treatAsWhitelist = createOption(
+        "option.drop_confirm.treat_as_whitelist",
+        "option.drop_confirm.treat_as_whitelist.description",
+        defaults.treatAsWhitelist,
+        () -> config.treatAsWhitelist,
+        val -> config.treatAsWhitelist = val,
+        booleanOption -> new BooleanController(booleanOption, true)
+      );
+
       var confirmationResetDelay = createOption(
         "option.drop_confirm.confirmation_reset_delay",
         "option.drop_confirm.confirmation_reset_delay.description",
@@ -84,7 +96,7 @@ public final class DropConfirmConfig {
         .title(Text.translatable("config.drop_confirm.title"))
         .category(
           defaultCategoryBuilder
-            .options(List.of(enabled, playSounds, confirmationResetDelay))
+            .options(List.of(enabled, playSounds, confirmationResetDelay, treatAsWhitelist))
             .group(blacklistedItems)
             .build()
         );

--- a/src/main/java/xyz/pupbrained/config/DropConfirmConfig.java
+++ b/src/main/java/xyz/pupbrained/config/DropConfirmConfig.java
@@ -81,9 +81,12 @@ public final class DropConfirmConfig {
         doubleOption -> new DoubleSliderController(doubleOption, 1.0, 5.0, 0.05)
       );
 
+      // FIXME: Figure out a way to update the strings instantly
+      //        Currently, the strings are only updated when the
+      //        config screen is reloaded.
       var blacklistedItems = createListOption(
-        "option.drop_confirm.blacklisted_items",
-        "option.drop_confirm.blacklisted_items.description",
+        config.treatAsWhitelist ? "option.drop_confirm.whitelisted_items" : "option.drop_confirm.blacklisted_items",
+        config.treatAsWhitelist ? "option.drop_confirm.whitelisted_items.description" : "option.drop_confirm.blacklisted_items.description",
         defaults.blacklistedItems,
         () -> config.blacklistedItems,
         val -> config.blacklistedItems = val,

--- a/src/main/java/xyz/pupbrained/mixin/ItemDropMixin.java
+++ b/src/main/java/xyz/pupbrained/mixin/ItemDropMixin.java
@@ -34,8 +34,11 @@ public abstract class ItemDropMixin {
     final var inventory = player.getInventory();
     var itemStack = inventory.getMainHandStack();
 
-    if (config.blacklistedItems.contains(itemStack.getItem()))
+    if (config.blacklistedItems.contains(itemStack.getItem())) {
+      if(!config.treatAsWhitelist) return;
+    } else if (config.treatAsWhitelist) {
       return;
+    }
 
     if (!Util.confirmed) {
       mc.inGameHud.setOverlayMessage(

--- a/src/main/resources/assets/drop_confirm/lang/en_us.json
+++ b/src/main/resources/assets/drop_confirm/lang/en_us.json
@@ -12,6 +12,8 @@
   "option.drop_confirm.enabled.description": "Whether DropConfirm should be enabled.",
   "option.drop_confirm.play_sounds": "Play Sounds",
   "option.drop_confirm.play_sounds.description": "Whether DropConfirm should play sounds for various events.",
+  "option.drop_confirm.treat_as_whitelist": "Treat as white list",
+  "option.drop_confirm.treat_as_whitelist.description": "Whether the blacklist should be used as a whitelist.",
   "option.drop_confirm.blacklisted_items": "Blacklisted Items",
   "option.drop_confirm.blacklisted_items.description": "Items that should be ignored by DropConfirm."
 }

--- a/src/main/resources/assets/drop_confirm/lang/en_us.json
+++ b/src/main/resources/assets/drop_confirm/lang/en_us.json
@@ -13,7 +13,9 @@
   "option.drop_confirm.play_sounds": "Play Sounds",
   "option.drop_confirm.play_sounds.description": "Whether DropConfirm should play sounds for various events.",
   "option.drop_confirm.treat_as_whitelist": "Treat as white list",
-  "option.drop_confirm.treat_as_whitelist.description": "Whether the blacklist should be used as a whitelist.",
+  "option.drop_confirm.treat_as_whitelist.description": "Whether the blacklist should be used as a whitelist.\n\nNOTE: This change takes effect instantly, but will only show visually upon re-entering the config screen.",
   "option.drop_confirm.blacklisted_items": "Blacklisted Items",
-  "option.drop_confirm.blacklisted_items.description": "Items that should be ignored by DropConfirm."
+  "option.drop_confirm.blacklisted_items.description": "Items that should be ignored by DropConfirm.",
+  "option.drop_confirm.whitelisted_items": "Whitelisted Items",
+  "option.drop_confirm.whitelisted_items.description": "Items that should not be ignored by DropConfirm."
 }


### PR DESCRIPTION
I only really wanted to protect my netherite tools.

That would mean having to blacklist every other block in the game.

This allows you to set what you want protected and ignore everything else.

It only has an english translation at the moment.

https://github.com/pupbrained/drop-confirm/assets/44343744/f05653d3-a647-452f-9da4-7e900903b340



Oh I also added workflow dispatch to the build workflow, because being able to manually trigger is usefull. Can obviously remove that if you dont want it.